### PR TITLE
chore: improve runtime lint

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -51,12 +51,10 @@ const config: Configuration = {
    ** Nuxt.js dev-modules
    */
   buildModules: [
-    // Doc: https://github.com/nuxt-community/eslint-module
-    '@nuxtjs/eslint-module',
     // Doc: https://github.com/nuxt-community/stylelint-module
     '@nuxtjs/stylelint-module',
     // Doc: https://typescript.nuxtjs.org/
-    '@nuxt/typescript-build'
+    ['@nuxt/typescript-build', { typeCheck: { eslint: true } }]
   ],
   /*
    ** Nuxt.js modules
@@ -84,21 +82,11 @@ const config: Configuration = {
         // Caution: https://github.com/postcss/autoprefixer#beware-of-enabling-autoplacement-in-old-projects
         autoprefixer: SUPPORT_IE === 'true' ? { grid: 'autoplace' } : {}
       }
-    },
+    }
     /*
      ** You can extend webpack config here
      */
-    extend(config, ctx) {
-      if (ctx.isDev && ctx.isClient) {
-        config.module!.rules.push({
-          enforce: 'pre',
-          test: /\.(js|ts|vue)$/,
-          loader: 'eslint-loader',
-          exclude: /(node_modules)/,
-          options: { cache: true, fix: true }
-        })
-      }
-    }
+    // extend(config, ctx) {},
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1270,16 +1270,6 @@
         "@typescript-eslint/parser": "^2.9.0"
       }
     },
-    "@nuxtjs/eslint-module": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/eslint-module/-/eslint-module-1.1.0.tgz",
-      "integrity": "sha512-9np9tKQ30ULIfT7Zshhw9Gc8Xf437/X7jUGG2Wv4SwT26Miu0WE0q9FNXUt9gxaBIQuokKiWsoTT28rXUaxHjQ==",
-      "dev": true,
-      "requires": {
-        "consola": "^2.10.1",
-        "eslint-loader": "^3.0.0"
-      }
-    },
     "@nuxtjs/proxy": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@nuxtjs/proxy/-/proxy-1.3.3.tgz",
@@ -4527,19 +4517,6 @@
         }
       }
     },
-    "eslint-loader": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-3.0.2.tgz",
-      "integrity": "sha512-S5VnD+UpVY1PyYRqeBd/4pgsmkvSokbHqTXAQMpvCyRr3XN2tvSLo9spm2nEpqQqh9dezw3os/0zWihLeOg2Rw==",
-      "dev": true,
-      "requires": {
-        "fs-extra": "^8.1.0",
-        "loader-fs-cache": "^1.0.2",
-        "loader-utils": "^1.2.3",
-        "object-hash": "^1.3.1",
-        "schema-utils": "^2.2.0"
-      }
-    },
     "eslint-module-utils": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
@@ -7251,57 +7228,6 @@
         }
       }
     },
-    "loader-fs-cache": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.2.tgz",
-      "integrity": "sha512-70IzT/0/L+M20jUlEqZhZyArTU6VKLRTYRDAYN26g4jfzpJqjipLL3/hgYpySqI9PwsVRHHFja0LfEmsx9X2Cw==",
-      "dev": true,
-      "requires": {
-        "find-cache-dir": "^0.1.1",
-        "mkdirp": "0.5.1"
-      },
-      "dependencies": {
-        "find-cache-dir": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
-          "dev": true,
-          "requires": {
-            "commondir": "^1.0.1",
-            "mkdirp": "^0.5.1",
-            "pkg-dir": "^1.0.0"
-          }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "pkg-dir": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-          "dev": true,
-          "requires": {
-            "find-up": "^1.0.0"
-          }
-        }
-      }
-    },
     "loader-runner": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
@@ -8441,12 +8367,6 @@
         }
       }
     },
-    "object-hash": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
-      "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==",
-      "dev": true
-    },
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
@@ -8801,21 +8721,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
     },
     "pkg-dir": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
   "devDependencies": {
     "@nuxt/typescript-build": "^0.3.10",
     "@nuxtjs/eslint-config-typescript": "^1.0.0",
-    "@nuxtjs/eslint-module": "^1.1.0",
     "@nuxtjs/stylelint-module": "^3.1.1",
     "@types/faker": "^4.1.8",
     "aspida": "^0.7.0",

--- a/plugins/axios.ts
+++ b/plugins/axios.ts
@@ -2,6 +2,7 @@ import { Context } from '@nuxt/types'
 
 export default ({ $axios }: Context) => {
   $axios.onError((error) => {
+    // eslint-disable-next-line no-console
     console.log(error)
   })
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,5 +28,9 @@
       "@nuxt/types",
       "@nuxtjs/axios"
     ]
-  }
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }


### PR DESCRIPTION
@nuxtjs/eslint-module の依存を削除し、fork-ts-checker-webpack-plugin で ESLint のチェックも行うように設定を変更しました。
`tsconfig.json` に `"allowJs": true` が設定されており、かつ `nuxt-ts generate` で書き出された `dist` が存在する場合、fork-ts-checker-webpack-plugin のチェックが終わらない、プロセスの停止ができない、という挙動を確認したので、`tsconfig.json` に `exclude` の設定をあらためて追加しました。

`console.log()` があると `nuxt-ts generate`（`NODE_ENV=production`）でエラーで終了してしまうので、除外するコメントを追加しています。
※ `nuxt-ts`（`NODE_ENV=development`）の場合は `Warning` なのでコメントがなくても開発可能です。