### PR TITLE
fixed README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ``` bash
 # install dependencies
-$ npm run install
+$ npm install
 
 # serve with hot reload at localhost:3000
 $ npm run dev


### PR DESCRIPTION
- 事象
インストールコマンド"npm run install"を実行すると、"missing script"のエラーが出力される。

- 対応
README.mdのインストールコマンドを"npm install"に修正しました。(動作確認済)

- 備考
@hi85gh に調査いただいたところ、[create-nuxt-appのtemplate](https://github.com/nuxt/create-nuxt-app/tree/master/template#readme)にあるREADME.md自体が誤っているのが根本原因でした。
create-nuxt-appのリポジトリ側は、[こちらのPR](https://github.com/nuxt/create-nuxt-app/pull/401)がマージされると対応完了になりそうです。
